### PR TITLE
Fixed bug within  parser in launchdXPC

### DIFF
--- a/Src/launchdXPC/launchdXPC.m
+++ b/Src/launchdXPC/launchdXPC.m
@@ -1,5 +1,5 @@
 //
-//  launchdXPC.c
+//  launchdXPC.m
 //  Created by Patrick Wardle
 //  Ported from code by Jonathan Levin
 //
@@ -238,7 +238,7 @@ NSMutableDictionary* parse(NSString* data)
         
         //end key line? (line: "}")
         // remove dictionary, as it's no longer needed
-        if(YES == [obj hasSuffix:@"}"])
+        if(YES == [obj isEqualToString:@"}"])
         {
             //remove
             [dictionaries removeLastObject];

--- a/Src/main.swift
+++ b/Src/main.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-let version = 0.6
+let version = 0.7
 
 // Go through command line arguments and set accordingly
 let argManager = ArgManager(suppliedArgs:CommandLine.arguments)


### PR DESCRIPTION
On macOS 14.4 the launchdXPC parser would choke on the following line due to the fact it's all on one line.

BSServiceDomains => {"XPCService":{"Services":{"InternalService":{},"MainService":{}}}}