### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@
 Read all about the TrueTree concept [here](https://themittenmac.com/the-truetree-concept/)
 
 
-TrueTree is more than just a pstree command for macOS. It is used to display a process tree for current running processes while using a hierarchy built on additoinal pids that can be collected from the operating system.  The standard process tree on macOS that can be built with traditional pids and ppids is less than helpful on macOS due to all the XPC communication at play.  The vast majority of processes end up having a parent process of launchd. TrueTree however displays a process tree that is meant to be useful to incident responders, threat hunters, researchers, and everything in between!  
+TrueTree is more than just a pstree command for macOS. It is used to display a process tree for current running processes while using a hierarchy built on additional pids that can be collected from the operating system.  The standard process tree on macOS that can be built with traditional pids and ppids is less than helpful on macOS due to all the XPC communication at play.  The vast majority of processes end up having a parent process of launchd. TrueTree however displays a process tree that is meant to be useful to incident responders, threat hunters, researchers, and everything in between!  
 
 Major Update:
-Because of the ever changing features on macOS, since macOS 11 some features don't operate quite the same as they used to when I wrote the original blog post for TrueTree. Apple has introduced the addition of a new process "runningboardd" which ends up being the true parent of many processes. To get around this TrueTree was updated to use the Application Services framework which allowed for aquiring the true parent in some scenarios. However, this no longer allows for the aquiring of a true parent process if that parent process has terminated. Making it difficult to pinpoint some true parents such as the "open" command. A small price to pay to ensure TrueTree continues to operate across macOS releases. Some other signs of a true parent can often be found inside of the launchctl procinfo output. This might be taken into consideration in the future.
+Because of the ever-changing features on macOS, since macOS 11 some features don't operate quite the same as they used to when I wrote the original blog post for TrueTree. Apple has introduced the addition of a new process "runningboardd" which ends up being the true parent of many processes. To get around this TrueTree was updated to use the Application Services framework which allowed for acquiring the true parent in some scenarios. However, this no longer allows for the acquiring of a true parent process if that parent process has terminated. Making it difficult to pinpoint some true parents such as the "open" command. A small price to pay to ensure TrueTree continues to operate across macOS releases. Some other signs of a true parent can often be found inside of the launchctl procinfo output. This might be taken into consideration in the future.
 
 **./TrueTree -h** \
 --nocolor -> Do not color code items in output
@@ -41,7 +41,7 @@ For output in either format with process create time added use the --timestamps 
 <br/><br/>
 
 **./TrueTree --sources** \
-To show where each parent pid was aquired from use the --sources option
+To show where each parent pid was acquired from use the --sources option
 <p align="center"><img src="https://themittenmac.com/wp-content/uploads/2022/12/tt_sources.png"></p>
 <br/><br/>
 

--- a/Src/node.swift
+++ b/Src/node.swift
@@ -74,11 +74,11 @@ extension Node {
                 }
                 if argManager.showpid { text += "    \(String(pid).magenta)"}
                 if argManager.timestamps { text += "    \(timestamp.cyan)"}
-                if argManager.sources { text += "    Aquired parent from -> \(source)".red }
+                if argManager.sources { text += "    Acquired parent from -> \(source)".red }
             } else {
                 text = "\(displayString)    \(String(pid))"
                 if argManager.timestamps { text += "    \(timestamp)"}
-                if argManager.sources { text += "    Aquired parent from -> \(source)" }
+                if argManager.sources { text += "    Acquired parent from -> \(source)" }
             }
             
         }


### PR DESCRIPTION
% `codespell ` # https://pypi.org/project/codespell
```
./README.md:9: additoinal ==> additional
./README.md:12: aquiring ==> acquiring
./README.md:12: aquiring ==> acquiring
./README.md:44: aquired ==> acquired
./Src/node.swift:77: Aquired ==> Acquired
./Src/node.swift:81: Aquired ==> Acquired
```